### PR TITLE
add current limits

### DIFF
--- a/code/src/main/java/frc/robot/loggers/TalonFXLogger.java
+++ b/code/src/main/java/frc/robot/loggers/TalonFXLogger.java
@@ -1,5 +1,6 @@
 package frc.robot.loggers;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Celsius;
 
 import com.ctre.phoenix6.hardware.TalonFX;
@@ -18,6 +19,7 @@ public class TalonFXLogger extends ClassSpecificLogger<TalonFX> {
     @Override
     public void update(EpilogueBackend backend, TalonFX motor) {
         backend.log("Output", motor.get());
+        backend.log("Stator Current", motor.getStatorCurrent().getValue().in(Amps));
         backend.log("Temp", motor.getDeviceTemp().getValue().in(Celsius));
         backend.log("Temp Processor", motor.getProcessorTemp().getValue().in(Celsius));
     }

--- a/code/src/main/java/frc/robot/subsystems/Arm.java
+++ b/code/src/main/java/frc/robot/subsystems/Arm.java
@@ -4,6 +4,7 @@
 
 package frc.robot.subsystems;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Kilograms;
 import static edu.wpi.first.units.Units.Meters;
@@ -15,6 +16,7 @@ import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Seconds;
 import static edu.wpi.first.units.Units.Volts;
 
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 
@@ -113,6 +115,10 @@ public class Arm extends SubsystemBase {
   /** Creates a new Arm. */
   public Arm() {
     SmartDashboard.putData("Arm Sim", mech2d);
+
+    var angleMotorCurrentLimits = new CurrentLimitsConfigs().withStatorCurrentLimit(Amps.of(60))
+        .withStatorCurrentLimitEnable(true);
+    armMotor.getConfigurator().apply(angleMotorCurrentLimits);
   }
 
   public void simulationPeriodic() {

--- a/code/src/main/java/frc/robot/subsystems/Elevator.java
+++ b/code/src/main/java/frc/robot/subsystems/Elevator.java
@@ -8,9 +8,9 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.Robot;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Centimeters;
 import static edu.wpi.first.units.Units.Kilograms;
-import static edu.wpi.first.units.Units.Meter;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
@@ -19,6 +19,7 @@ import static edu.wpi.first.units.Units.Volts;
 
 import java.util.function.BooleanSupplier;
 
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.sim.TalonFXSimState;
 
@@ -99,6 +100,10 @@ public class Elevator extends SubsystemBase {
   public Elevator() {
     stop();
     elevatorMotor.setInverted(motorInverted);
+    var angleMotorCurrentLimits = new CurrentLimitsConfigs().withStatorCurrentLimit(Amps.of(80))
+        .withStatorCurrentLimitEnable(true);
+    elevatorMotor.getConfigurator().apply(angleMotorCurrentLimits);
+
     if (Robot.isSimulation()) {
       limitSwitch = () -> getPosition().isNear(minHeight, Meters.of(0.01));
     } else {

--- a/code/src/main/java/frc/robot/subsystems/swerve/SwerveModuleReal.java
+++ b/code/src/main/java/frc/robot/subsystems/swerve/SwerveModuleReal.java
@@ -4,6 +4,7 @@
 
 package frc.robot.subsystems.swerve;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.Radians;
@@ -11,6 +12,7 @@ import static edu.wpi.first.units.Units.Rotations;
 import static edu.wpi.first.units.Units.RotationsPerSecond;
 import static edu.wpi.first.units.Units.Volts;
 
+import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.hardware.CANcoder;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.NeutralModeValue;
@@ -47,6 +49,11 @@ public class SwerveModuleReal implements SwerveModuleBase {
     anglePID.enableContinuousInput(-Math.PI, Math.PI);
     encoder = new CANcoder(encoderPort);
     angleMotor.setNeutralMode(NeutralModeValue.Brake);
+
+    var angleMotorCurrentLimits = new CurrentLimitsConfigs().withStatorCurrentLimit(Amps.of(60))
+        .withStatorCurrentLimitEnable(true);
+    angleMotor.getConfigurator().apply(angleMotorCurrentLimits);
+
   }
 
   @Override


### PR DESCRIPTION
implements current limits in some appropriate locations to help increase battery performance by reducing load, along with reducing the peak output of subsystems that have end-stops to avoid subsystems from causing too much damage to themselves. these values need to be tested and will require re-running sysid