### PR TITLE
Deploy Auditing

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -29,6 +29,29 @@ deploy {
                 frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
                 }
 
+                File fullPath = new File('src/main/deploy/audit')
+                    if (!fullPath.exists())
+                        fullPath.mkdirs()
+
+                new File('src/main/deploy/audit/machine.txt').text = providers.exec {
+                    commandLine("hostname")
+                }.standardOutput.asText.get()
+
+                // Nothing is printed when there are no local changes
+                new File('src/main/deploy/audit/status.txt').text = providers.exec {
+                    commandLine("git", "status", "--short")
+                }.standardOutput.asText.get()
+
+                 // Note: Nothing is output in a detached head
+                new File('src/main/deploy/audit/branch.txt').text = providers.exec {
+                    commandLine("git", "branch", "--show-current")
+                }.standardOutput.asText.get()
+
+                // Note: Nothing is output in a detached head
+                new File('src/main/deploy/audit/HEAD.txt').text = providers.exec {
+                    commandLine("git", "rev-parse", "HEAD")
+                }.standardOutput.asText.get()
+
                 // Static files artifact
                 frcStaticFileDeploy(getArtifactTypeClass('FileTreeArtifact')) {
                     files = project.fileTree('src/main/deploy')

--- a/code/src/main/deploy/elastic-layout.json
+++ b/code/src/main/deploy/elastic-layout.json
@@ -3,25 +3,257 @@
   "grid_size": 128,
   "tabs": [
     {
-      "name": "Teleoperated",
-      "grid_layout": {
-        "layouts": [],
-        "containers": []
-      }
-    },
-    {
-      "name": "Autonomous",
+      "name": "Preflight",
       "grid_layout": {
         "layouts": [
           {
-            "title": "Align",
+            "title": "Deploy",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 384.0,
+            "height": 512.0,
+            "type": "List Layout",
+            "properties": {
+              "label_position": "TOP"
+            },
+            "children": [
+              {
+                "title": "isClean",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Boolean Box",
+                "properties": {
+                  "topic": "/SmartDashboard/Deploy/isClean",
+                  "period": 0.06,
+                  "data_type": "boolean",
+                  "true_color": 4283215696,
+                  "false_color": 4294198070,
+                  "true_icon": "None",
+                  "false_icon": "None"
+                }
+              },
+              {
+                "title": "Branch",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/SmartDashboard/Deploy/Branch",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "status",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/SmartDashboard/Deploy/status",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "HEAD",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/SmartDashboard/Deploy/HEAD",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              },
+              {
+                "title": "machine",
+                "x": 0.0,
+                "y": 0.0,
+                "width": 128.0,
+                "height": 128.0,
+                "type": "Text Display",
+                "properties": {
+                  "topic": "/SmartDashboard/Deploy/machine",
+                  "period": 0.06,
+                  "data_type": "string",
+                  "show_submit_button": false
+                }
+              }
+            ]
+          }
+        ],
+        "containers": [
+          {
+            "title": "autoChooser",
+            "x": 640.0,
+            "y": 128.0,
+            "width": 512.0,
+            "height": 128.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/autoChooser",
+              "period": 0.06,
+              "sort_options": false
+            }
+          },
+          {
+            "title": "Alerts",
+            "x": 384.0,
+            "y": 0.0,
+            "width": 256.0,
+            "height": 512.0,
+            "type": "Alerts",
+            "properties": {
+              "topic": "/SmartDashboard/Alerts",
+              "period": 0.06
+            }
+          },
+          {
+            "title": "Limelight Toggle",
+            "x": 640.0,
+            "y": 256.0,
+            "width": 512.0,
+            "height": 128.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/Limelight Toggle",
+              "period": 0.06,
+              "sort_options": false
+            }
+          },
+          {
+            "title": "FMSInfo",
+            "x": 640.0,
+            "y": 0.0,
+            "width": 384.0,
+            "height": 128.0,
+            "type": "FMSInfo",
+            "properties": {
+              "topic": "/FMSInfo",
+              "period": 0.06
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Teleoperated",
+      "grid_layout": {
+        "layouts": [],
+        "containers": [
+          {
+            "title": "limelight-front",
+            "x": 0.0,
+            "y": 0.0,
+            "width": 512.0,
+            "height": 512.0,
+            "type": "Camera Stream",
+            "properties": {
+              "topic": "/CameraPublisher/limelight-front",
+              "period": 0.06
+            }
+          },
+          {
+            "title": "Field",
+            "x": 512.0,
+            "y": 128.0,
+            "width": 768.0,
+            "height": 384.0,
+            "type": "Field",
+            "properties": {
+              "topic": "/SmartDashboard/Field",
+              "period": 0.06,
+              "field_game": "Reefscape",
+              "robot_width": 0.82,
+              "robot_length": 0.96,
+              "show_other_objects": true,
+              "show_trajectories": true,
+              "field_rotation": 0.0,
+              "robot_color": 4294198070,
+              "trajectory_color": 4294967295
+            }
+          },
+          {
+            "title": "Limelight Toggle",
+            "x": 1280.0,
+            "y": 256.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/Limelight Toggle",
+              "period": 0.06,
+              "sort_options": false
+            }
+          },
+          {
+            "title": "Robot Orientation Mode",
+            "x": 1280.0,
+            "y": 384.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "ComboBox Chooser",
+            "properties": {
+              "topic": "/SmartDashboard/Robot Orientation Mode",
+              "period": 0.06,
+              "sort_options": false
+            }
+          },
+          {
+            "title": "Alerts",
             "x": 1280.0,
             "y": 0.0,
             "width": 256.0,
             "height": 256.0,
+            "type": "Alerts",
+            "properties": {
+              "topic": "/SmartDashboard/Alerts",
+              "period": 0.06
+            }
+          },
+          {
+            "title": "Match Timer",
+            "x": 512.0,
+            "y": 0.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Match Time",
+            "properties": {
+              "topic": "/SmartDashboard/Match Timer",
+              "period": 0.06,
+              "data_type": "double",
+              "time_display_mode": "Minutes and Seconds",
+              "red_start_time": 15,
+              "yellow_start_time": 30
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Commands",
+      "grid_layout": {
+        "layouts": [
+          {
+            "title": "Align",
+            "x": 512.0,
+            "y": 0.0,
+            "width": 256.0,
+            "height": 512.0,
             "type": "List Layout",
             "properties": {
-              "label_position": "TOP"
+              "label_position": "HIDDEN"
             },
             "children": [
               {
@@ -101,7 +333,20 @@
                   "period": 0.06,
                   "show_type": true
                 }
-              },
+              }
+            ]
+          },
+          {
+            "title": "Align",
+            "x": 768.0,
+            "y": 0.0,
+            "width": 256.0,
+            "height": 512.0,
+            "type": "List Layout",
+            "properties": {
+              "label_position": "HIDDEN"
+            },
+            "children": [
               {
                 "title": "G",
                 "x": 0.0,
@@ -137,32 +382,6 @@
                 "type": "Command",
                 "properties": {
                   "topic": "/SmartDashboard/Align/I",
-                  "period": 0.06,
-                  "show_type": true
-                }
-              },
-              {
-                "title": "IntakeLeft",
-                "x": 0.0,
-                "y": 0.0,
-                "width": 256.0,
-                "height": 128.0,
-                "type": "Command",
-                "properties": {
-                  "topic": "/SmartDashboard/Align/IntakeLeft",
-                  "period": 0.06,
-                  "show_type": true
-                }
-              },
-              {
-                "title": "IntakeRight",
-                "x": 0.0,
-                "y": 0.0,
-                "width": 256.0,
-                "height": 128.0,
-                "type": "Command",
-                "properties": {
-                  "topic": "/SmartDashboard/Align/IntakeRight",
                   "period": 0.06,
                   "show_type": true
                 }
@@ -211,102 +430,62 @@
         ],
         "containers": [
           {
-            "title": "autoChooser",
+            "title": "Reset Pose",
             "x": 0.0,
             "y": 0.0,
             "width": 256.0,
             "height": 128.0,
-            "type": "ComboBox Chooser",
+            "type": "Command",
             "properties": {
-              "topic": "/SmartDashboard/autoChooser",
+              "topic": "/SmartDashboard/Reset Pose",
               "period": 0.06,
-              "sort_options": false
+              "show_type": true
             }
           },
           {
-            "title": "limelight-front",
+            "title": "IntakeLeft",
             "x": 0.0,
-            "y": 128.0,
-            "width": 512.0,
-            "height": 384.0,
-            "type": "Camera Stream",
+            "y": 384.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Command",
             "properties": {
-              "topic": "/CameraPublisher/limelight-front",
-              "period": 0.06
+              "topic": "/SmartDashboard/Align/IntakeLeft",
+              "period": 0.06,
+              "show_type": true
+            }
+          },
+          {
+            "title": "IntakeRight",
+            "x": 256.0,
+            "y": 384.0,
+            "width": 256.0,
+            "height": 128.0,
+            "type": "Command",
+            "properties": {
+              "topic": "/SmartDashboard/Align/IntakeRight",
+              "period": 0.06,
+              "show_type": true
             }
           },
           {
             "title": "Field",
-            "x": 512.0,
+            "x": 0.0,
             "y": 128.0,
-            "width": 768.0,
-            "height": 384.0,
+            "width": 512.0,
+            "height": 256.0,
             "type": "Field",
             "properties": {
               "topic": "/SmartDashboard/Field",
               "period": 0.06,
               "field_game": "Reefscape",
-              "robot_width": 0.8,
-              "robot_length": 0.9,
+              "robot_width": 0.85,
+              "robot_length": 0.85,
               "show_other_objects": true,
               "show_trajectories": true,
               "field_rotation": 0.0,
               "robot_color": 4294198070,
               "trajectory_color": 4294967295
-            }
-          },
-          {
-            "title": "Limelight Toggle",
-            "x": 768.0,
-            "y": 0.0,
-            "width": 256.0,
-            "height": 128.0,
-            "type": "ComboBox Chooser",
-            "properties": {
-              "topic": "/SmartDashboard/Limelight Toggle",
-              "period": 0.06,
-              "sort_options": false
-            }
-          },
-          {
-            "title": "Robot Orientation Mode",
-            "x": 512.0,
-            "y": 0.0,
-            "width": 256.0,
-            "height": 128.0,
-            "type": "ComboBox Chooser",
-            "properties": {
-              "topic": "/SmartDashboard/Robot Orientation Mode",
-              "period": 0.06,
-              "sort_options": false
-            }
-          },
-          {
-            "title": "Alerts",
-            "x": 1280.0,
-            "y": 256.0,
-            "width": 256.0,
-            "height": 256.0,
-            "type": "Alerts",
-            "properties": {
-              "topic": "/SmartDashboard/Alerts",
-              "period": 0.06
-            }
-          },
-          {
-            "title": "Match Timer",
-            "x": 1024.0,
-            "y": 0.0,
-            "width": 256.0,
-            "height": 128.0,
-            "type": "Match Time",
-            "properties": {
-              "topic": "/SmartDashboard/Match Timer",
-              "period": 0.06,
-              "data_type": "double",
-              "time_display_mode": "Minutes and Seconds",
-              "red_start_time": 15,
-              "yellow_start_time": 30
             }
           }
         ]

--- a/code/src/main/java/frc/robot/Audit.java
+++ b/code/src/main/java/frc/robot/Audit.java
@@ -1,0 +1,49 @@
+package frc.robot;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import edu.wpi.first.wpilibj.Filesystem;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+public class Audit {
+
+    public String branch;
+    public String head;
+    public String machine;
+    public String status;
+
+    public boolean isCleanDeploy;
+
+    Audit() {
+        // Get Audit data
+        var deploy = Filesystem.getDeployDirectory();
+        try {
+            branch = Files.readString(deploy.toPath().resolve("audit/branch.txt")).trim();
+            head = Files.readString(deploy.toPath().resolve("audit/HEAD.txt")).trim();
+            machine = Files.readString(deploy.toPath().resolve("audit/machine.txt")).trim();
+            status = Files.readString(deploy.toPath().resolve("audit/status.txt")).trim();
+            isCleanDeploy = branch == "main" && status == "";
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void printDeployInformation() {
+        System.out
+                .println("\n----- Deploy Information: -----\n" + branch + " " + machine + " " + head + "\n" + status);
+    }
+
+    public void updateSmartDashboard() {
+        SmartDashboard.putBoolean("Deploy/isClean", isCleanDeploy);
+        SmartDashboard.putString("Deploy/Branch", branch);
+        // Converted to csv because smart dashboard does not render multi-line strings
+        SmartDashboard.putString("Deploy/status", Arrays.stream(status.split("\n"))
+                .collect(Collectors.joining(",")));
+        SmartDashboard.putString("Deploy/HEAD", head);
+        SmartDashboard.putString("Deploy/machine", machine);
+    }
+
+}

--- a/code/src/main/java/frc/robot/Audit.java
+++ b/code/src/main/java/frc/robot/Audit.java
@@ -14,7 +14,6 @@ public class Audit {
     public String head;
     public String machine;
     public String status;
-
     public boolean isCleanDeploy;
 
     Audit() {
@@ -25,7 +24,7 @@ public class Audit {
             head = Files.readString(deploy.toPath().resolve("audit/HEAD.txt")).trim();
             machine = Files.readString(deploy.toPath().resolve("audit/machine.txt")).trim();
             status = Files.readString(deploy.toPath().resolve("audit/status.txt")).trim();
-            isCleanDeploy = branch == "main" && status == "";
+            isCleanDeploy = branch.equals("main") && status.equals("");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -33,7 +32,7 @@ public class Audit {
 
     public void printDeployInformation() {
         System.out
-                .println("\n----- Deploy Information: -----\n" + branch + " " + machine + " " + head + "\n" + status);
+                .println("\n----- Deploy Information -----\n" + branch + " " + machine + " " + head + "\n" + status);
     }
 
     public void updateSmartDashboard() {

--- a/code/src/main/java/frc/robot/Audit.java
+++ b/code/src/main/java/frc/robot/Audit.java
@@ -10,11 +10,11 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class Audit {
 
-    public String branch;
-    public String head;
-    public String machine;
-    public String status;
-    public boolean isCleanDeploy;
+    private String branch;
+    private String head;
+    private String machine;
+    private String status;
+    private boolean isCleanDeploy;
 
     Audit() {
         // Get Audit data

--- a/code/src/main/java/frc/robot/Robot.java
+++ b/code/src/main/java/frc/robot/Robot.java
@@ -4,6 +4,9 @@
 
 package frc.robot;
 
+import java.io.IOException;
+import java.nio.file.Files;
+
 import edu.wpi.first.epilogue.Epilogue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.logging.FileBackend;
@@ -11,10 +14,12 @@ import edu.wpi.first.epilogue.logging.NTEpilogueBackend;
 import edu.wpi.first.epilogue.logging.errors.ErrorHandler;
 import edu.wpi.first.net.WebServer;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.shuffleboard.EventImportance;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -27,6 +32,8 @@ public class Robot extends TimedRobot {
   private Command m_autonomousCommand;
 
   private final RobotContainer m_robotContainer;
+
+  static Audit audit = new Audit();
 
   @SuppressWarnings("unused")
   public Robot() {
@@ -77,6 +84,9 @@ public class Robot extends TimedRobot {
     WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
     // Initialize Robot
     m_robotContainer = new RobotContainer();
+
+    audit.updateSmartDashboard();
+    audit.printDeployInformation();
   }
 
   @Override

--- a/code/src/main/java/frc/robot/Robot.java
+++ b/code/src/main/java/frc/robot/Robot.java
@@ -4,9 +4,6 @@
 
 package frc.robot;
 
-import java.io.IOException;
-import java.nio.file.Files;
-
 import edu.wpi.first.epilogue.Epilogue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.logging.FileBackend;
@@ -14,12 +11,10 @@ import edu.wpi.first.epilogue.logging.NTEpilogueBackend;
 import edu.wpi.first.epilogue.logging.errors.ErrorHandler;
 import edu.wpi.first.net.WebServer;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.Alert;
 import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
-import edu.wpi.first.wpilibj.Alert.AlertType;
 import edu.wpi.first.wpilibj.shuffleboard.EventImportance;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;

--- a/code/src/main/java/frc/robot/Robot.java
+++ b/code/src/main/java/frc/robot/Robot.java
@@ -84,7 +84,9 @@ public class Robot extends TimedRobot {
     WebServer.start(5800, Filesystem.getDeployDirectory().getPath());
     // Initialize Robot
     m_robotContainer = new RobotContainer();
-
+    
+    // Outputting the audit data is intentionally done last to be confident that the robot
+    // did not crash during the initial start-up, and can be confident the deploy succeeded
     audit.updateSmartDashboard();
     audit.printDeployInformation();
   }


### PR DESCRIPTION
Adds Deploy auditing to the code. Including outputting brach, head, status, machine, and whether the deploy is "clean". A clean deploy is one that is from main with no uncommitted changes.

Data is output to dashboard for easy preflight checking and is included in the Robot logs.

Note: This change adds a hard dependency on having the `git` CLI installed on any computer that is going to deploy. It does not need to be authenticated.

Simulator restarts do not trigger updating Deploy data. However, since the auditing is for real robot deploys, this is acceptable behavior


Unclean Deploy:
![image](https://github.com/user-attachments/assets/ce3dd5e7-4ffe-4be4-ad11-13e77c2775a2)

Clean Deploy:
![image](https://github.com/user-attachments/assets/cdbd06e5-a63a-424f-912e-f664d07fa1b9)
