### PR TITLE
Swerve encoders fixed

### DIFF
--- a/code/src/main/java/frc/robot/subsystems/swerve/SwerveModuleReal.java
+++ b/code/src/main/java/frc/robot/subsystems/swerve/SwerveModuleReal.java
@@ -34,6 +34,7 @@ import edu.wpi.first.wpilibj.Alert.AlertType;
 @Logged
 public class SwerveModuleReal implements SwerveModuleBase {
   private Alert encoderDisconnectedAlert;
+  public boolean driveIsInverted = true;
 
   public TalonFX driveMotor;
   public TalonFX angleMotor;
@@ -51,6 +52,7 @@ public class SwerveModuleReal implements SwerveModuleBase {
 
     driveMotor = new TalonFX(driveMotorPort);
     angleMotor = new TalonFX(angleMotorPort);
+    driveMotor.setInverted(driveIsInverted);
     anglePID.enableContinuousInput(-Math.PI, Math.PI);
     encoder = new CANcoder(encoderPort);
     angleMotor.setNeutralMode(NeutralModeValue.Brake);


### PR DESCRIPTION
Reversed drive motor because the encoders were reversed. However, as a consequence, the raw output that we get from advantage scope is off. #102 